### PR TITLE
chore: rename to Wan2GP Desktop Launcher Tauri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wan2gp-tauri-spike",
+  "name": "wan2gp-desktop-launcher-tauri",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wan2gp-tauri-spike",
+      "name": "wan2gp-desktop-launcher-tauri",
       "version": "0.1.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wan2gp-tauri-spike",
+  "name": "wan2gp-desktop-launcher-tauri",
   "private": true,
   "version": "0.1.1",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "wan2gp-tauri-spike"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "reqwest",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wan2gp-tauri-spike"
+name = "wan2gp-desktop-launcher-tauri"
 version = "0.1.2"
 description = "A Tauri App"
 authors = ["you"]
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "wan2gp_tauri_spike_lib"
+name = "wan2gp_desktop_launcher_tauri_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    wan2gp_tauri_spike_lib::run();
+    wan2gp_desktop_launcher_tauri_lib::run();
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
     "$schema":  "https://schema.tauri.app/config/2",
-    "productName":  "wan2gp-tauri-spike",
+    "productName":  "Wan2GP Desktop Launcher Tauri",
     "version":  "0.1.2",
     "identifier":  "com.wangp.desktop-tauri",
     "build":  {


### PR DESCRIPTION
Renames productName + Cargo package/binary to Wan2GP Desktop Launcher Tauri.

Updater-safe: identifier, endpoint and pubkey unchanged; next release just needs version > 0.1.2 and latest.json will point at the new filenames.