### PR TITLE
feat: topbar cleanup (port Electron 131a45c)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2856,22 +2856,6 @@ document.querySelectorAll('input[name="termDock"]').forEach(r => {
 // F12 is built-in DevTools shortcut. The IPC handler in main.js is kept
 // (it opens the BrowserView DevTools when embedded), just no UI button needed.
 
-// Topbar refresh: re-poll dashboard + hardware + a fresh metrics tick
-$('refreshBtn')?.addEventListener('click', async () => {
-  try { refreshDashboard() } catch {}
-  try { loadHardware() } catch {}
-  try {
-    const m = await window.w2gp.getSystemMetrics()
-    if (m) {
-      if (m.ramFree) { const el = $('specRamFree'); if (el) el.textContent = '(' + m.ramFree + ' free)' }
-      if (m.vramFree) { const el = $('specVramFree'); if (el) el.textContent = '(' + m.vramFree + ' free)' }
-      // nudge sparkline redraw via the polling tick
-      if (window.__metricsTick) window.__metricsTick()
-    }
-  } catch {}
-  showToast('Refreshed')
-})
-
 $('tokenSaveBtn')?.addEventListener('click', async () => {
   const token = $('githubTokenInput')?.value
   if (!token) return

--- a/src/index.html
+++ b/src/index.html
@@ -413,19 +413,16 @@
           <div class="metric" id="metricVram2" style="display:none" title="VRAM 2"><span class="metric-label">VRAM2</span><canvas class="metric-spark" id="sparkVram2" width="44" height="18"></canvas><span class="metric-val" id="valVram2">—</span></div>
         </div>
         <div id="wvControls" class="wv-controls" style="display:none">
-          <button class="btn-icon wv-btn" id="wvReloadBtn" aria-label="Reload"><svg viewBox="0 0 24 24" width="14" height="14"><path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg></button>
           <span class="wv-sep"></span>
           <input type="range" id="zoomSlider" class="zoom-slider" min="25" max="200" value="100" title="Zoom">
           <span class="zoom-label" id="zoomLabel">100%</span>
           <span class="wv-sep"></span>
           <button class="btn btn-ghost small" id="backToDashboardBtn">← Back to Dashboard</button>
           <button class="btn btn-ghost small" id="ftToggleBtn" title="Toggle floating terminal console">⊞ Console</button>
+          <button class="btn-icon wv-btn" id="wvReloadBtn" aria-label="Reload Wan2GP view" title="Reload Wan2GP view"><svg viewBox="0 0 24 24" width="14" height="14"><path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg></button>
         </div>
         <button class="btn-icon" id="stopWangpBtn" title="Stop Wan2GP server" style="display:none">
           <svg viewBox="0 0 24 24" width="14" height="14"><rect x="6" y="6" width="12" height="12" rx="1" fill="currentColor"/></svg>
-        </button>
-        <button class="btn-icon" id="refreshBtn" title="Refresh dashboard &amp; metrics">
-          <svg viewBox="0 0 24 24" width="14" height="14"><path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
         </button>
         <button class="btn btn-ghost small" id="taskMgrBtn" title="Open Windows Task Manager">
           <svg viewBox="0 0 24 24" width="14" height="14"><rect x="3" y="4" width="18" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="9" x2="16" y2="9" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="13" x2="14" y2="13" stroke="currentColor" stroke-width="1.5"/><line x1="8" y1="17" x2="12" y2="17" stroke="currentColor" stroke-width="1.5"/></svg>

--- a/src/style.css
+++ b/src/style.css
@@ -123,8 +123,8 @@ body {
 .topbar-left { flex: 0 0 auto; min-width: 0; -webkit-app-region: no-drag; }
 .topbar-right { flex: 1 1 0; min-width: 0; display: flex; align-items: center; gap: 6px; justify-content: flex-end; -webkit-app-region: no-drag; }
 .topbar-center {
-  position: absolute; left: 16px;
   display: flex; align-items: center; gap: 8px; pointer-events: none; white-space: nowrap;
+  flex: 0 1 auto; min-width: 0; overflow: hidden;
 }
 .brand-mark-small {
   font-family: 'Instrument Serif', 'Georgia', serif; font-size: 1.25rem; font-weight: 400;
@@ -132,7 +132,7 @@ body {
   display: flex; align-items: center; gap: 2px;
 }
 .brand-mark-small span { color: var(--text-primary); }
-.app-title { font-size: 0.8125rem; font-weight: 500; color: var(--text-primary); }
+.app-title { font-size: 0.8125rem; font-weight: 500; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; }
 .app-version {
   font-size: 0.6rem; font-weight: 500; color: var(--text-tertiary);
   background: var(--surface-hover); border: 1px solid var(--border);
@@ -156,6 +156,8 @@ body {
   line-height: 0;
 }
 .btn-icon:hover { background: var(--surface-hover); color: var(--text-primary); }
+#stopWangpBtn { color: #EF4444; }
+#stopWangpBtn:hover { background: rgba(239,68,68,.14); color: #EF4444; }
 .btn-icon svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
 .btn-ghost {
   background: transparent; color: var(--text-secondary); border: 1px solid var(--border);
@@ -923,8 +925,10 @@ body {
 .toggle-row input { accent-color: var(--accent); width: 16px; height: 16px; }
 
 /* ── Topbar live metrics (CPU/GPU/RAM/VRAM sparklines) ── */
-.topbar-metrics { display: flex; align-items: center; gap: 12px; margin-right: 10px; -webkit-app-region: no-drag; }
-.metric { display: flex; align-items: center; gap: 4px; font-size: 0.56rem; color: var(--text-tertiary); font-family: 'Geist Mono', monospace; }
+.topbar-metrics { display: flex; align-items: center; gap: 12px; margin-right: 10px; -webkit-app-region: no-drag; flex: 0 1 auto; min-width: 0; overflow: hidden; }
+@media (max-width: 1150px) { .metric-spark { display: none; } }
+@media (max-width: 900px) { .app-title { display: none; } }
+.metric { display: flex; align-items: center; gap: 4px; flex-shrink: 0; font-size: 0.56rem; color: var(--text-tertiary); font-family: 'Geist Mono', monospace; }
 .metric-label { font-weight: 600; color: var(--text-secondary); letter-spacing: 0.03em; }
 .metric-spark { width: 44px; height: 18px; display: block; background: var(--surface-hover); border-radius: 2px; }
 .metric-val { min-width: 30px; text-align: right; color: var(--text-primary); }


### PR DESCRIPTION
Ports Electron 131a45c topbar cleanup to Tauri:

- Remove refreshBtn button + handler (polling already covers refresh)
- Move wvReloadBtn after Console with title (was first, untitled)
- Red stop button (#EF4444)
- Overlap fix: topbar-center/metrics flex with overflow hidden, title ellipsis
- Responsive: hide sparks <=1150px, title <=900px

Back/fwd/popout were already gone in Tauri. Dead popout/nav-state compat shims in w2gp.js + backend left untouched per scope.