### PR TITLE
feat: launcher update check shortly after boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes. Dates are release dates; `Unreleased` tracks `master`.
 
 ## [Unreleased]
 
+- Launcher update check runs once shortly after boot (5h poll alone left fresh releases unknown for hours)
+
 ## [0.1.3]
 
 - Renamed to Wan2GP Desktop Launcher Tauri (product, binary, installer)

--- a/src/app.js
+++ b/src/app.js
@@ -757,6 +757,13 @@ function startDesktopPolling() {
     try { window.w2gp.checkUpdate() } catch {}
   }
   window.__desktopPollTimer = setInterval(poll, DESKTOP_POLL_MS)
+  // One early check shortly after boot — the 5h interval alone means a fresh
+  // release sits unknown for hours (seen with v0.1.3). Delayed, not immediate,
+  // so backend/network are up and the boot sequence stays undisturbed.
+  if (!window.__desktopBootCheckDone) {
+    window.__desktopBootCheckDone = true
+    setTimeout(poll, 30000)
+  }
   if (!window.__desktopVisBound) {
     window.__desktopVisBound = () => {
       if (document.hidden) {


### PR DESCRIPTION
One delayed (+30s) update check after boot; 5h interval unchanged. Fresh releases no longer sit unknown for hours.