### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 All notable changes. Dates are release dates; `Unreleased` tracks `master`.
 
-## [0.2.1] — 2026-09-04
-
-- Live console download bars: bootstrap shim actually wired into launch (isatty patch, HF progress env, `HUGGINGFACE_HUB_TOKEN` mirror, per-launch temp file) — model/LoRA downloads stream tqdm bars
-
-## [Unreleased]
+## [0.3.0] — 2026-09-05
 
 - DLSS5 status now counts `host/nvngx.dll` (8 files, was 7) and README tracks workers v1.1.3 (upstream `33eb156`)
 - Launcher update check runs once shortly after boot (5h poll alone left fresh releases unknown for hours)
+
+## [Unreleased]
+
+## [0.2.1] — 2026-09-04
+
+- Live console download bars: bootstrap shim actually wired into launch (isatty patch, HF progress env, `HUGGINGFACE_HUB_TOKEN` mirror, per-launch temp file) — model/LoRA downloads stream tqdm bars
 
 ## [0.2.0] — 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes. Dates are release dates; `Unreleased` tracks `master`.
 
 ## [Unreleased]
 
+- DLSS5 status now counts `host/nvngx.dll` (8 files, was 7) and README tracks workers v1.1.3 (upstream `33eb156`)
 - Launcher update check runs once shortly after boot (5h poll alone left fresh releases unknown for hours)
 
 ## [0.2.0] — 2026-09-04

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Switching live-re-renders the selector; **Apply** writes a consistent `wgp_confi
 
 ## ✨ DLSS5 installer — optional NVIDIA upsamplers
 
-Dashboard card runs WanGP's own `scripts/install_dlss5.ps1` (workers v1.1.2, ReShade 6.8.0, RenoDX 4.70, DLSSNR 310.8.SF-v2, DLSS 310.8.0, Frame Generation 310.7.0) into `C:\Wan2GP\dlss5\` with a live per-component checklist — downloading → SHA-256 ✓ → installed — plus console progress.
+Dashboard card runs WanGP's own `scripts/install_dlss5.ps1` (workers v1.1.3, ReShade 6.8.0, RenoDX 4.70, DLSSNR 310.8.SF-v2, DLSS 310.8.0, Frame Generation 310.7.0) into `C:\Wan2GP\dlss5\` with a live per-component checklist — downloading → SHA-256 ✓ → installed — plus console progress.
 
 ![DLSS5 installer — live per-component checklist with SHA-256 verification](screenshots/dlss5-checklist.png)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Through the launcher you get the **full WanGP** — same models, same UI, same p
 
 > Full history: [CHANGELOG.md](CHANGELOG.md)
 
+- **v0.3.0** — DLSS5 status counts all 8 runtime files (+ `host/nvngx.dll`), README tracks workers v1.1.3; update check runs once shortly after boot.
 - **v0.2.1** — live console download bars (bootstrap fix).
 - **v0.2.0** — 🧩 Plugin Manager tab (Status Pro default plugin, favourites auto-install) · ✨ DLSS5 one-click installer with live SHA checklist · Deepy local Qwen3.8 Prime + Claude bridge 0.1.66 + npm/`cmd /C` fix · Auto-Tune Int8 Kernels default-on · maximized window · scoped Stop (only our processes).
 - **v0.1.3** — renamed to Wan2GP Desktop Launcher Tauri (product, binary, installer); topbar cleanup (Electron port): reload after Console, red stop button, no title overlap.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2gp-desktop-launcher-tauri",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "wan2gp-desktop-launcher-tauri"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wan2gp-desktop-launcher-tauri"
-version = "0.2.1"
+version = "0.3.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -342,7 +342,7 @@ pub async fn install_prerequisite(app: tauri::AppHandle, tool: String) -> Result
     Ok(serde_json::json!({"ok": true, "success": true}))
 }
 
-const DLSS5_FILES: &[&str] = &["host/nr-depth-worker.exe", "host/dxgi.dll", "host/renodx-dlss5.addon64", "host/nvngx_dlssnr.dll", "dlss/nvngx_dlss.dll", "dlssg/nvngx_dlssg.dll", "dlssg/dlssg-worker.exe"];
+const DLSS5_FILES: &[&str] = &["host/nr-depth-worker.exe", "host/nvngx.dll", "host/dxgi.dll", "host/renodx-dlss5.addon64", "host/nvngx_dlssnr.dll", "dlss/nvngx_dlss.dll", "dlssg/nvngx_dlssg.dll", "dlssg/dlssg-worker.exe"];
 
 #[tauri::command]
 pub fn dlss5_status() -> serde_json::Value {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema":  "https://schema.tauri.app/config/2",
     "productName":  "Wan2GP Desktop Launcher Tauri",
-    "version":  "0.2.1",
+    "version":  "0.3.0",
     "identifier":  "com.wangp.desktop-tauri",
     "build":  {
                   "frontendDist":  "../src"


### PR DESCRIPTION
DLSS5 status counts all 8 runtime files (+ host/nvngx.dll), README tracks workers v1.1.3 (upstream 33eb156); update check runs once shortly after boot.