### PR TITLE
0.4.3: backend hardening, honest installer, DLSS/KeyError UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes. Dates are release dates; `Unreleased` tracks `master`.
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-09-06
+
+- Hardened backend: pip spec guard (blocks --flags/-r/-e/http tarballs), exit-code propagation everywhere (no more false success), https-only plugin installs
+- Honest prerequisites: winget Python exact-pin check, Store-shim filter, git live-resolve + SHA-pinned installers, working Python fallback (3.11.9 — 3.11.14 ships no binary), uv fallback Bypass fix
+- Drift fixes: Intel XPU profile (no NVIDIA wheels on Arc), pip preview uses the real validator, SpargeAttention dedup
+- Frontend: baseline CSP + trimmed capabilities, DLSS consent as a real popup, KeyError crash recovery (backup + reset + relaunch)
+
 ## [0.4.2] — 2026-09-06
 
 - Self-repairing toolchain: a corrupt uv (not just outdated) is reinstalled automatically with one retry; failure diagnostics include the manual reinstall command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes. Dates are release dates; `Unreleased` tracks `master`.
 - Hardened backend: pip spec guard (blocks --flags/-r/-e/http tarballs), exit-code propagation everywhere (no more false success), https-only plugin installs
 - Honest prerequisites: winget Python exact-pin check, Store-shim filter, git live-resolve + SHA-pinned installers, working Python fallback (3.11.9 — 3.11.14 ships no binary), uv fallback Bypass fix
 - Drift fixes: Intel XPU profile (no NVIDIA wheels on Arc), pip preview uses the real validator, SpargeAttention dedup
-- Frontend: baseline CSP + trimmed capabilities, DLSS consent as a real popup, KeyError crash recovery (backup + reset + relaunch)
+- Frontend: baseline CSP + trimmed capabilities, DLSS consent as a real popup (shared modal convention, checkbox instead of typed I ACCEPT), KeyError crash recovery (backup + reset + relaunch)
+- Fail fast when the install drive has <10 GB free (mirrors the model-drive gate instead of dying of ENOSPC mid-setup)
 
 ## [0.4.2] — 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Through the launcher you get the **full WanGP** — same models, same UI, same p
 
 > Full history: [CHANGELOG.md](CHANGELOG.md)
 
-- **v0.4.3** — hardened backend (pip guard, honest exit codes, https-only plugins) + fixed prerequisites (pin checks, SHA-pinned installers, working Python/uv fallbacks) + KeyError crash recovery and DLSS consent popup.
+- **v0.4.3** — hardened backend (pip guard, honest exit codes, https-only plugins) + fixed prerequisites (pin checks, SHA-pinned installers, working Python/uv fallbacks) + KeyError crash recovery, DLSS consent checkbox popup, and install-drive space gate.
 - **v0.4.2** — self-repairing toolchain (corrupt uv reinstalled automatically with retry) + winget-independent prerequisites (official-installer fallbacks, smarter probes).
 - **v0.4.1** — prerequisites that finish the job (one-click git/uv/Python/Miniconda, registry PATH refresh with auto-continue, `py -3.11` shim for venv) + Python fallback that counts (usable manual installs accepted, exact-verify, diagnostics).
 - **v0.4.0 — hardened installer.** No more silent failures: target-folder triage (fresh / repair / reuse / migrate), exact-Python preflight, honest exit codes with Retry + diagnostics, post-install torch+CUDA smoke test, reinstall backup dialog with model relocation, Pinokio detection with one-click model reuse, launch guards, and truthful phase tracking.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Through the launcher you get the **full WanGP** — same models, same UI, same p
 
 > Full history: [CHANGELOG.md](CHANGELOG.md)
 
+- **v0.4.3** — hardened backend (pip guard, honest exit codes, https-only plugins) + fixed prerequisites (pin checks, SHA-pinned installers, working Python/uv fallbacks) + KeyError crash recovery and DLSS consent popup.
 - **v0.4.2** — self-repairing toolchain (corrupt uv reinstalled automatically with retry) + winget-independent prerequisites (official-installer fallbacks, smarter probes).
 - **v0.4.1** — prerequisites that finish the job (one-click git/uv/Python/Miniconda, registry PATH refresh with auto-continue, `py -3.11` shim for venv) + Python fallback that counts (usable manual installs accepted, exact-verify, diagnostics).
 - **v0.4.0 — hardened installer.** No more silent failures: target-folder triage (fresh / repair / reuse / migrate), exact-Python preflight, honest exit codes with Retry + diagnostics, post-install torch+CUDA smoke test, reinstall backup dialog with model relocation, Pinokio detection with one-click model reuse, launch guards, and truthful phase tracking.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wan2gp-desktop-launcher-tauri",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "wan2gp-desktop-launcher-tauri"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "reqwest",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4903,6 +4903,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ sysinfo = "0.39.6"
 tauri-plugin-updater = "2.11.0"
 reqwest = { version = "0.13.4", features = ["json"] }
 chrono = "0.4"
+sha2 = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wan2gp-desktop-launcher-tauri"
-version = "0.4.2"
+version = "0.4.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,9 +6,6 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "shell:default",
-    "dialog:default",
-    "fs:default",
     "updater:default"
   ]
 }

--- a/src-tauri/src/base.rs
+++ b/src-tauri/src/base.rs
@@ -267,3 +267,131 @@ pub(crate) fn split_cmdline(s: &str) -> (String, Vec<String>) {
 }
 
 pub(crate) static WANGP_PID: OnceLock<Mutex<Option<u32>>> = OnceLock::new();
+
+/// Validate a pip specifier before it reaches `pip install/upgrade/uninstall`.
+/// Rust port of services/pip-spec.js `assertSafePipSpec` — keep the two in
+/// sync (same accept/reject table, same comments). Rejects pip options
+/// (pip parses argv options itself — no shell needed for `--opt=val` to take
+/// effect), shell metacharacters, path separators, and non-https URLs.
+/// Accepted: bare name, name with PEP 440 pin, https .whl/.tar.gz/.zip URL.
+pub(crate) fn pip_spec_ok(spec: &str) -> Result<(), String> {
+    if spec.is_empty() { return Err("empty package spec".into()); }
+    // Whitespace / shell metacharacters outright. `<` and `>` are allowed:
+    // they are valid PEP 440 operators (>=, <=) and argv has no shell, so
+    // they can never cause redirection. (is_whitespace covers the JS \s class
+    // and then some — strictly stronger than pip-spec.js, same verdicts.)
+    if spec.chars().any(|c| c.is_whitespace() || ";&|$`(){}'\"".contains(c)) {
+        return Err("unsafe characters in package spec".into());
+    }
+    // Direct wheel/URL install (no shell chars already guaranteed).
+    if let Some(rest) = spec.strip_prefix("https://") {
+        let base = rest.split('?').next().unwrap_or("");
+        let ok_ext = base.ends_with(".whl") || base.ends_with(".tar.gz") || base.ends_with(".zip");
+        if base.is_empty() || !ok_ext { return Err("bad wheel URL (https + .whl/.tar.gz/.zip only)".into()); }
+        return Ok(());
+    }
+    if spec.contains('/') || spec.contains('\\') { return Err("path separators not allowed".into()); }
+    // Split a possible version specifier: name [OP version] (==, >=, <=, ~=, !=, >, <).
+    let cut = spec.find(|c| "<>=!~".contains(c));
+    let (name, tail) = match cut {
+        Some(i) => (&spec[..i], &spec[i..]),
+        None => (spec, ""),
+    };
+    let mut nc = name.chars();
+    match nc.next() {
+        Some(c) if c.is_ascii_alphabetic() => {}
+        _ => return Err(format!("bad package name: {name}")),
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || "._-".contains(c)) {
+        return Err(format!("bad package name: {name}"));
+    }
+    if !tail.is_empty() {
+        let op_len = ["==", ">=", "<=", "~=", "!="].iter()
+            .find(|op| tail.starts_with(**op)).map(|s| s.len())
+            .unwrap_or_else(|| if tail.starts_with('<') || tail.starts_with('>') { 1 } else { 0 });
+        if op_len == 0 || tail[op_len..].is_empty()
+            || !tail[op_len..].chars().all(|c| c.is_ascii_alphanumeric() || "._:*!+-".contains(c)) {
+            return Err("malformed version pin".into());
+        }
+    }
+    // Must not look like an option even after all the above.
+    if spec.starts_with('-') { return Err("pip options are not accepted here".into()); }
+    Ok(())
+}
+
+#[cfg(test)]
+mod pip_spec_tests {
+    use super::pip_spec_ok;
+    #[test]
+    fn accepts_well_formed_specs() {
+        for s in [
+            "claude-agent-sdk",
+            "claude-agent-sdk==0.1.66",
+            "foo>=1.0",
+            "torch<=2.10.0",
+            "pkg~=1.4.2",
+            "pkg!=1.0",
+            "pkg>1.0",
+            "pkg<2.0",
+            "https://download.pytorch.org/whl/foo-1.0-py3-none-any.whl",
+            "https://example.com/a.tar.gz?x=1",
+        ] { assert!(pip_spec_ok(s).is_ok(), "should accept {s}"); }
+    }
+    #[test]
+    fn rejects_dangerous_specs() {
+        for s in [
+            "", "-r", "-r requirements.txt", "-e .", "--index-url", "--index-url=https://evil/x",
+            "--no-deps", "-c evil.conf", "foo; rm -rf", "foo|bar", "foo&bar", "foo$(bar)",
+            "foo`bar`", "foo bar", "../evil", "a/b", "http://evil/x.whl",
+            "https://evil/x.exe", "--upgrade", "-U", "-q foo",
+        ] { assert!(pip_spec_ok(s).is_err(), "should reject {s}"); }
+    }
+}
+
+/// PATH probe that refuses to count the Microsoft Store stub as a real tool.
+/// `where python` succeeds on the Store shim (it only opens the Store), so a
+/// bare exit-status check reports "installed" on machines with no Python.
+/// Same filter diagnose_python_fail applies — centralized here so probe_tool
+/// and check_command can't drift again. Windows-only; elsewhere every
+/// `which` hit is a real binary.
+#[cfg(windows)]
+pub(crate) fn tool_usable(cmd: &str) -> bool {
+    silent_command("where").arg(cmd).output().ok()
+        .and_then(|o| o.status.success().then(|| String::from_utf8_lossy(&o.stdout).to_string()))
+        .is_some_and(|s| s.lines().any(|l| {
+            let p = l.trim();
+            !p.is_empty() && !p.to_lowercase().contains("windowsapps")
+        }))
+}
+
+/// Spawn a shell-plugin child, stream stdout+stderr to `emit`, and return
+/// true iff the exit code is 0. The single choke point for fallible backend
+/// commands (pip install/upgrade/uninstall, git pull, per-kernel sync) so a
+/// failure can never again read as success. `Terminated.code == None`
+/// (killed/signalled) counts as failure.
+pub(crate) async fn run_logged(
+    app: &tauri::AppHandle,
+    prog: &str,
+    args: &[&str],
+    dir: Option<&Path>,
+    emit: impl Fn(&str),
+) -> bool {
+    use tauri_plugin_shell::{ShellExt, process::CommandEvent};
+    let mut cmd = app.shell().command(prog);
+    cmd = cmd.args(args);
+    if let Some(d) = dir { cmd = cmd.current_dir(d); }
+    let (mut rx, _) = match cmd.spawn() {
+        Ok(t) => t,
+        Err(e) => { emit(&format!("[!] spawn failed ({prog}): {e}\n")); return false; }
+    };
+    let mut code: Option<i32> = None;
+    while let Some(ev) = rx.recv().await {
+        match ev {
+            CommandEvent::Stdout(b) | CommandEvent::Stderr(b) => emit(&String::from_utf8_lossy(&b)),
+            CommandEvent::Terminated(p) => { code = p.code; }
+            CommandEvent::Error(e) => emit(&format!("[!] {e}\n")),
+            _ => {}
+        }
+    }
+    code == Some(0)
+}

--- a/src-tauri/src/features.rs
+++ b/src-tauri/src/features.rs
@@ -2,8 +2,6 @@
 use tauri::Emitter;
 use std::path::PathBuf;
 use crate::base::*;
-use tauri_plugin_shell::process::CommandEvent;
-use tauri_plugin_shell::ShellExt;
 use crate::{hw::get_gpu_info_sync, status::get_active_env};
 
 #[tauri::command]
@@ -160,29 +158,41 @@ pub fn auto_tune_recommend(hw: Option<serde_json::Value>, opts: Option<serde_jso
 // ── Phase 2-5: remaining 65 handlers as thin stubs (real logic behind shell/fs plugins) ──
 #[tauri::command]
 pub async fn upgrade_package(app: tauri::AppHandle, pkg: String) -> Result<serde_json::Value,String> {
+    pip_spec_ok(&pkg).map_err(|e| format!("blocked: {e}"))?;
     let env = get_active_env(); let raw = env.get("path").and_then(|p| p.as_str()).unwrap_or(""); let base = if std::path::Path::new(raw).is_absolute() { PathBuf::from(raw) } else { get_repo_dir().join(raw.trim_start_matches(".\\").trim_start_matches("./")) };
     let py = if cfg!(windows) { base.join("Scripts\\python.exe") } else { base.join("bin/python") };
     if !py.exists() { return Err("python not found".into()); }
-    let (mut rx, _) = app.shell().command(&py).args(["-m","pip","install","--upgrade", &pkg]).spawn().map_err(|e| e.to_string())?;
-    while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let _ = app.emit("launch-log", String::from_utf8_lossy(&b).to_string()); }, _=>{} } }
+    let py_s = py.to_string_lossy().to_string();
+    let emit = |m: &str| { let _ = app.emit("launch-log", m.to_string()); };
+    if !run_logged(&app, &py_s, &["-m","pip","install","--upgrade", &pkg], None, emit).await {
+        return Err(format!("pip upgrade {pkg} failed — see console output"));
+    }
     Ok(serde_json::json!({"ok": true, "success": true}))
 }
 #[tauri::command]
 pub async fn install_package(app: tauri::AppHandle, pkg: String) -> Result<serde_json::Value,String> {
+    pip_spec_ok(&pkg).map_err(|e| format!("blocked: {e}"))?;
     let env = get_active_env(); let raw = env.get("path").and_then(|p| p.as_str()).unwrap_or(""); let base = if std::path::Path::new(raw).is_absolute() { PathBuf::from(raw) } else { get_repo_dir().join(raw.trim_start_matches(".\\").trim_start_matches("./")) };
     let py = if cfg!(windows) { base.join("Scripts\\python.exe") } else { base.join("bin/python") };
     if !py.exists() { return Err("python not found".into()); }
-    let (mut rx, _) = app.shell().command(&py).args(["-m","pip","install", &pkg]).spawn().map_err(|e| e.to_string())?;
-    while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let _ = app.emit("launch-log", String::from_utf8_lossy(&b).to_string()); }, _=>{} } }
+    let py_s = py.to_string_lossy().to_string();
+    let emit = |m: &str| { let _ = app.emit("launch-log", m.to_string()); };
+    if !run_logged(&app, &py_s, &["-m","pip","install", &pkg], None, emit).await {
+        return Err(format!("pip install {pkg} failed — see console output"));
+    }
     Ok(serde_json::json!({"ok": true, "success": true}))
 }
 #[tauri::command]
 pub async fn uninstall_package(app: tauri::AppHandle, pkg: String) -> Result<serde_json::Value,String> {
+    pip_spec_ok(&pkg).map_err(|e| format!("blocked: {e}"))?;
     let env = get_active_env(); let raw = env.get("path").and_then(|p| p.as_str()).unwrap_or(""); let base = if std::path::Path::new(raw).is_absolute() { PathBuf::from(raw) } else { get_repo_dir().join(raw.trim_start_matches(".\\").trim_start_matches("./")) };
     let py = if cfg!(windows) { base.join("Scripts\\python.exe") } else { base.join("bin/python") };
     if !py.exists() { return Err("python not found".into()); }
-    let (mut rx, _) = app.shell().command(&py).args(["-m","pip","uninstall","-y", &pkg]).spawn().map_err(|e| e.to_string())?;
-    while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let _ = app.emit("launch-log", String::from_utf8_lossy(&b).to_string()); }, _=>{} } }
+    let py_s = py.to_string_lossy().to_string();
+    let emit = |m: &str| { let _ = app.emit("launch-log", m.to_string()); };
+    if !run_logged(&app, &py_s, &["-m","pip","uninstall","-y", &pkg], None, emit).await {
+        return Err(format!("pip uninstall {pkg} failed — see console output"));
+    }
     Ok(serde_json::json!({"ok": true, "success": true}))
 }
 #[tauri::command]
@@ -190,8 +200,11 @@ pub async fn restore_requirements(app: tauri::AppHandle) -> Result<serde_json::V
     let repo = get_repo_dir(); let env = get_active_env(); let raw = env.get("path").and_then(|p| p.as_str()).unwrap_or(""); let base = if std::path::Path::new(raw).is_absolute() { PathBuf::from(raw) } else { repo.join(raw.trim_start_matches(".\\").trim_start_matches("./")) };
     let py = if cfg!(windows) { base.join("Scripts\\python.exe") } else { base.join("bin/python") };
     if !py.exists() { return Err("python not found".into()); }
-    let (mut rx, _) = app.shell().command(&py).args(["-m","pip","install","-r", "requirements.txt"]).current_dir(&repo).spawn().map_err(|e| e.to_string())?;
-    while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let _ = app.emit("launch-log", String::from_utf8_lossy(&b).to_string()); }, _=>{} } }
+    let py_s = py.to_string_lossy().to_string();
+    let emit = |m: &str| { let _ = app.emit("launch-log", m.to_string()); };
+    if !run_logged(&app, &py_s, &["-m","pip","install","-r", "requirements.txt"], Some(&repo), emit).await {
+        return Err("requirements restore failed — see console output".into());
+    }
     Ok(serde_json::json!({"ok": true, "success": true}))
 }
 #[tauri::command] pub fn llm_engines_list() -> serde_json::Value {

--- a/src-tauri/src/hw.rs
+++ b/src-tauri/src/hw.rs
@@ -38,7 +38,11 @@ pub(crate) fn kernel_profile_key(vendor: &str, name: &str) -> String {
         if g.contains("9060")||g.contains("9070")||g.contains("8000")||g.contains("1201") { return "AMD_GFX1201".into(); }
         return "AMD_GFX110X".into();
     }
-    "RTX_40".into()
+    // Intel → XPU backend (install-plan.js); unknown → CPU. Never alias an
+    // NVIDIA profile: the overview would promise CUDA wheels the installer
+    // never installs (must match kernel-resolver.js kernelProfileKey).
+    if v == "INTEL" { return "INTEL_XPU".into(); }
+    "CPU".into()
 }
 pub(crate) fn build_install_plan(hw: &serde_json::Value) -> serde_json::Value {
     let vendor = hw.get("vendor").and_then(|v| v.as_str()).unwrap_or("UNKNOWN").to_uppercase();

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -224,14 +224,25 @@ fn diagnose_python_fail(wanted: &str) -> String {
     }
     let mut cands: Vec<String> = Vec::new();
     // PATH (skip the Microsoft Store shim — it opens the Store, not Python).
-    if let Ok(o) = silent_command("where").arg("python").output() {
-        if o.status.success() {
-            for line in String::from_utf8_lossy(&o.stdout).lines() {
-                let p = line.trim();
-                if !p.is_empty() && !p.to_lowercase().contains("windowsapps") { cands.push(p.to_string()); }
-            }
-        }
-    }
+    // `where` is Windows-only; POSIX uses `which -a` (a bare `where` probe
+    // just fails there and the diagnostic comes back empty).
+    #[cfg(windows)]
+    let path_hits: Vec<String> = silent_command("where").arg("python").output().ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).lines()
+            .map(|l| l.trim().to_string())
+            .filter(|p| !p.is_empty() && !p.to_lowercase().contains("windowsapps"))
+            .collect())
+        .unwrap_or_default();
+    #[cfg(not(windows))]
+    let path_hits: Vec<String> = silent_command("which").args(["-a", "python3.11"]).output().ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).lines()
+            .map(|l| l.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect())
+        .unwrap_or_default();
+    cands.extend(path_hits);
     #[cfg(windows)]
     for fixed in [
         std::env::var("LOCALAPPDATA").ok().map(|a| format!("{a}\\Programs\\Python\\Python311\\python.exe")),
@@ -952,7 +963,6 @@ pub async fn sync_kernels(app: tauri::AppHandle) -> Result<serde_json::Value,Str
     }
     let gpu = get_gpu_info_sync(); let profile = kernel_profile_key(gpu.get("vendor").and_then(|v| v.as_str()).unwrap_or(""), gpu.get("name").and_then(|v| v.as_str()).unwrap_or(""));
     let kernels = cfg.get("gpu_profiles").and_then(|p| p.get(&profile)).and_then(|pr| pr.get("kernels")).and_then(|k| k.as_array()).cloned().unwrap_or_default();
-    use tauri_plugin_shell::ShellExt; use tauri_plugin_shell::process::CommandEvent;
     let sage_safe = load_config_value().get("sageSafe").and_then(serde_json::Value::as_bool) != Some(false); // ponytail: default safe post6 (1348e5b) — only false opts into upstream post4
     // ponytail: Sage wheel is not in gpu_profiles[RTX_30].kernels (only nunchaku+gguf) — handle it separately like Electron's setSageAttentionSafe
     let mut all_kernels = kernels.clone();
@@ -962,6 +972,7 @@ pub async fn sync_kernels(app: tauri::AppHandle) -> Result<serde_json::Value,Str
             all_kernels.push(serde_json::json!("sage"));
         }
     }
+    let mut failed: Vec<String> = Vec::new();
     for k in all_kernels {
         if let Some(name) = k.as_str() {
             // find wheel url — nunchaku/gguf are under components.kernels, sage is under components.sage[profile.sage]
@@ -991,19 +1002,29 @@ pub async fn sync_kernels(app: tauri::AppHandle) -> Result<serde_json::Value,Str
                 }
             }
             let m = format!("[*] sync kernel {name}\n"); crate::base::push_log(&m, "setup"); let _ = app.emit("launch-log", m);
-            let (mut rx, _) = app.shell().command(&py).args(["-m","pip","install", &url, "--upgrade"]).spawn().map_err(|e| e.to_string())?;
-            while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let s = String::from_utf8_lossy(&b).to_string(); crate::base::push_log(&s, "setup"); let _ = app.emit("launch-log", s); }, _=>{} } }
+            let emit_k = |s: &str| { crate::base::push_log(s, "setup"); let _ = app.emit("launch-log", s.to_string()); };
+            let py_s = py.to_string_lossy().to_string();
+            if !run_logged(&app, &py_s, &["-m","pip","install", url.as_str(), "--upgrade"], None, emit_k).await {
+                failed.push(name.to_string());
+            }
         }
     }
-    mutating_done(); Ok(serde_json::json!({"ok": true, "success": true}))
+    mutating_done();
+    if !failed.is_empty() {
+        return Err(format!("kernel sync failed for: {} — see console output", failed.join(", ")));
+    }
+    Ok(serde_json::json!({"ok": true, "success": true}))
 }
 #[tauri::command]
 pub async fn update(app: tauri::AppHandle) -> Result<serde_json::Value,String> {
     mutating_try("update")?;
     let repo = get_repo_dir();
     if !repo.join(".git").exists() { mutating_done(); return Err("not a git repo".into()); }
-    let (mut rx, _) = app.shell().command("git").args(["pull"]).current_dir(&repo).spawn().map_err(|e| e.to_string())?;
-    while let Some(ev) = rx.recv().await { match ev { CommandEvent::Stdout(b)|CommandEvent::Stderr(b) => { let s = String::from_utf8_lossy(&b).to_string(); crate::base::push_log(&s, "setup"); let _ = app.emit("launch-log", s); }, _=>{} } }
+    let emit = |m: &str| { crate::base::push_log(m, "setup"); let _ = app.emit("launch-log", m.to_string()); };
+    if !run_logged(&app, "git", &["pull"], Some(&repo), emit).await {
+        mutating_done();
+        return Err("git pull failed — see console output (offline? diverged branch?)".into());
+    }
     mutating_done(); Ok(serde_json::json!({"ok": true, "success": true}))
 }
 pub(crate) fn fs_extra_fallback_copy_dir(src: &Path, dst: &Path) -> Result<(), String> {
@@ -1110,13 +1131,64 @@ fn probe_tool(tool: &str) -> bool {
     match tool {
         "git" => on_path("git"),
         "uv" => on_path("uv") || exists(format!("{home}\\.local\\bin\\uv.exe")) || exists(format!("{home}\\.cargo\\bin\\uv.exe")),
-        "python" => on_path("python") || on_path("py"),
+        "python" => tool_usable("python") || tool_usable("py"),
         "conda" => on_path("conda")
             || exists(format!("{home}\\Miniconda3\\condabin\\conda.bat"))
             || exists(format!("{home}\\Miniconda3\\Scripts\\conda.exe"))
             || exists(format!("{home}\\Anaconda3\\condabin\\conda.bat")),
         _ => false,
     }
+}
+
+/// Does this interpreter report exactly the wanted X.Y.Z?
+/// (`sys.version` prints e.g. "3.11.14 ..." — the first token must start with
+/// the full pin; a neighbouring patch like 3.11.9 does not count.)
+#[cfg(windows)]
+fn python_matches_pin(prog: &str, extra_args: &[&str], wanted: &str) -> bool {
+    let mut args: Vec<&str> = extra_args.to_vec();
+    args.extend(["-c", "import sys; print(sys.version)"]);
+    silent_command(prog).args(&args).output().ok()
+        .and_then(|o| o.status.success().then(|| String::from_utf8_lossy(&o.stdout).trim().split_whitespace().next().unwrap_or("").to_string()))
+        .is_some_and(|v| v.starts_with(wanted))
+}
+
+/// SHA-256 of a downloaded installer matches the pinned value? Downloads are
+/// TLS-only by default; a pin turns a MITM (or a truncated download) into a
+/// loud refusal instead of executed bytes. Streamed — the git installer is ~120 MB.
+#[cfg(windows)]
+fn verify_sha256(path: &str, expected_hex: &str, emit: &impl Fn(String)) -> bool {
+    use sha2::Digest;
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) => { emit(format!("[!] checksum: cannot read {path}: {e}\n")); return false; }
+    };
+    let mut hasher = sha2::Sha256::new();
+    if std::io::copy(&mut file, &mut hasher).is_err() {
+        emit(format!("[!] checksum: failed reading {path}\n"));
+        return false;
+    }
+    let got = format!("{:x}", hasher.finalize());
+    if got.eq_ignore_ascii_case(expected_hex) { return true; }
+    emit(format!("[!] CHECKSUM MISMATCH for {path}\n    got      {got}\n    expected {expected_hex}\n    refusing to run it — re-download manually from the official site.\n"));
+    false
+}
+
+/// (file-version, tag) of the newest Git for Windows, e.g.
+/// ("2.55.0.5", "v2.55.0.windows.5"). None when the API is unreachable —
+/// callers fall back to the pinned release.
+#[cfg(windows)]
+async fn latest_git_release() -> Option<(String, String)> {
+    let v: serde_json::Value = reqwest::Client::builder().user_agent("wan2gp-tauri")
+        .timeout(std::time::Duration::from_secs(10)).build().ok()?
+        .get("https://api.github.com/repos/git-for-windows/git/releases/latest")
+        .send().await.ok()?
+        .error_for_status().ok()?
+        .json().await.ok()?;
+    let tag = v.get("tag_name")?.as_str()?;
+    let base = tag.strip_prefix('v').unwrap_or(tag).split(".windows").next()?;
+    let n = tag.rsplit('.').next()?;
+    if base.is_empty() || !n.chars().all(|c| c.is_ascii_digit()) { return None; }
+    Some((format!("{base}.{n}"), tag.to_string()))
 }
 
 /// Official installers, used when winget is missing or fails (LTSC, removed
@@ -1136,24 +1208,55 @@ async fn official_fallback(app: &tauri::AppHandle, tool: &str) -> bool {
             run_live(app, "powershell", vec!["-NoProfile".into(), "-Command".into(), "& { iwr -useb https://astral.sh/uv/install.ps1 | iex }".into()]).await
         }
         "git" => {
-            // NOTE: update periodically — https://git-scm.com/download/win
-            let url = "https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe";
-            let dest = format!("{tmp}\\Git-2.49.0-64-bit.exe");
+            // Live-resolve the newest release; pinned fallback keeps offline installs working.
+            // The SHA pin covers the pinned fallback only — a newer live release is TLS-only (logged).
+            const FALLBACK_TAG: &str = "v2.55.0.windows.5";
+            const FALLBACK_VER: &str = "2.55.0.5";
+            const FALLBACK_SHA: &str = "d065a4e23c3d9a6b5073d609b5be0830227ec3ca053c083ba385061ddfaf94c6";
+            let (ver, tag) = latest_git_release().await
+                .unwrap_or((FALLBACK_VER.to_string(), FALLBACK_TAG.to_string()));
+            let mut url = format!("https://github.com/git-for-windows/git/releases/download/{tag}/Git-{ver}-64-bit.exe");
+            let mut dest = format!("{tmp}\\Git-{ver}-64-bit.exe");
+            let mut sha: Option<&str> = if ver.as_str() == FALLBACK_VER { Some(FALLBACK_SHA) } else { None };
             emit("[*] Downloading Git for Windows (~120 MB)…\n".into());
-            if !run_live(app, "powershell", download(url, &dest)).await { return false; }
+            if !run_live(app, "powershell", download(&url, &dest)).await || !std::path::Path::new(&dest).exists() {
+                if ver.as_str() != FALLBACK_VER {
+                    // Live asset name changed or offline — retry the pinned release.
+                    emit(format!("[!] Git {ver} download failed — retrying pinned Git {FALLBACK_VER}…\n"));
+                    url = format!("https://github.com/git-for-windows/git/releases/download/{FALLBACK_TAG}/Git-{FALLBACK_VER}-64-bit.exe");
+                    dest = format!("{tmp}\\Git-{FALLBACK_VER}-64-bit.exe");
+                    sha = Some(FALLBACK_SHA);
+                    if !run_live(app, "powershell", download(&url, &dest)).await { return false; }
+                } else { return false; }
+            }
+            match sha {
+                Some(s) if !verify_sha256(&dest, s, &emit) => return false,
+                None => emit(format!("[!] No pinned checksum for Git {ver} — trusting TLS.\n")),
+                _ => {}
+            }
             emit("[*] Installing silently — a couple of minutes…\n".into());
             run_live(app, &dest, vec!["/VERYSILENT".into(), "/NORESTART".into(), "/SUPPRESSMSGBOXES".into(), "/CLOSEAPPLICATIONS".into()]).await
         }
         "python" => {
-            // NOTE: keep in step with setup.py's pin (currently 3.11.14).
-            let url = "https://www.python.org/ftp/python/3.11.14/python-3.11.14-amd64.exe";
-            let dest = format!("{tmp}\\python-3.11.14-amd64.exe");
+            // python.org publishes NO binary installer for 3.11.14 (source-only
+            // security release — the old 3.11.14 URL 404s). 3.11.9 is the newest
+            // 3.11 with an official amd64 installer: good enough as a `py -3.11`
+            // source, while the exact 3.11.14 pin still comes via uv
+            // (python-build-standalone) — unaffected by this fallback. SHA
+            // pinned (hashed from python.org over TLS).
+            let url = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe";
+            let dest = format!("{tmp}\\python-3.11.9-amd64.exe");
+            const SHA: &str = "5ee42c4eee1e6b4464bb23722f90b45303f79442df63083f05322f1785f5fdde";
             emit("[*] Downloading Python 3.11 (~25 MB)…\n".into());
             if !run_live(app, "powershell", download(url, &dest)).await { return false; }
+            if !verify_sha256(&dest, SHA, &emit) { return false; }
             emit("[*] Installing silently — a couple of minutes…\n".into());
             run_live(app, &dest, vec!["/quiet".into(), "InstallAllUsers=0".into(), "PrependPath=1".into(), "Include_test=0".into()]).await
         }
         "conda" => {
+            // Trust surface (documented, not fixed): Miniconda3-latest is a moving
+            // target with no hash sidecar, so it cannot be SHA-pinned without
+            // freezing a version that would rot. TLS-only — same trust as setup.py itself.
             let url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe";
             let dest = format!("{tmp}\\Miniconda3-latest-Windows-x86_64.exe");
             let home = std::env::var("USERPROFILE").unwrap_or("C:\\Users\\Default".into());
@@ -1188,6 +1291,24 @@ async fn install_prerequisite_windows(app: tauri::AppHandle, tool: String) -> Re
     if !ok { return Err(format!("{tool} install failed — see output above (needs network; some packages need admin approval; check antivirus)")); }
     // Pick up the new PATH without a restart when possible.
     refresh_path_from_registry();
+    // winget's Python.Python.3.11 is latest 3.11.x, but setup.py demands the
+    // exact pin (pinned_python_wanted, e.g. 3.11.14). No usable python at all
+    // → take the (pinned 3.11.9) official installer; a real-but-neighbouring
+    // patch → keep it (uv provisions the exact pin automatically at install
+    // time) instead of pointlessly stacking a second interpreter.
+    if tool == "python" {
+        let wanted = pinned_python_wanted();
+        if !python_matches_pin("python", &[], &wanted) && !python_matches_pin("py", &["-3.11"], &wanted) {
+            if probe_tool(&tool) {
+                emit(&format!("[*] winget's Python isn't exactly {wanted} — keeping it; the installer provisions exactly {wanted} via uv automatically.\n"));
+            } else {
+                emit(&format!("[!] winget's Python isn't exactly {wanted} and no usable python found — installing the pinned build…\n"));
+                ok = official_fallback(&app, &tool).await;
+                if !ok { return Err(format!("{tool} install failed — see output above (needs network; some packages need admin approval; check antivirus)")); }
+                refresh_path_from_registry();
+            }
+        }
+    }
     if probe_tool(&tool) {
         emit(&format!("[✓] {tool} installed and on PATH — continuing…\n"));
         return Ok(serde_json::json!({"ok": true, "success": true, "ready": true}));
@@ -1224,6 +1345,9 @@ pub fn dlss5_status() -> serde_json::Value {
 }
 
 // Optional DLSS5 runtime (docs/DLSS5.md): runs Wan2GP's own Install-DLSS5.ps1.
+// Trust surface (documented, not fixed): upstream script executed with Bypass —
+// same trust as setup.py itself. Integrity comes from the pinned SHA-256
+// manifest above (verdict re-probes dlss5/, not script output).
 // Consent ("I ACCEPT") is taken in the UI modal, so the script gets
 // -AcceptThirdPartyRisk and never blocks on Read-Host. Verdict comes from
 // re-probing dlss5/, not from parsing script output.

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -163,7 +163,7 @@ async fn ensure_uv_python(app: &tauri::AppHandle, emit: impl Fn(&str) + Send + S
     if !dl_ok {
         emit("[*] uv itself may be broken — reinstalling uv from the official installer…\n");
         #[cfg(windows)]
-        let reinstalled = run_capture(app, &emit, "powershell", &["-NoProfile", "-Command", "& { iwr -useb https://astral.sh/uv/install.ps1 | iex }"]).await.0;
+        let reinstalled = run_capture(app, &emit, "powershell", &["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "& { iwr -useb https://astral.sh/uv/install.ps1 | iex }"]).await.0;
         #[cfg(not(windows))]
         let reinstalled = run_capture(app, &emit, "sh", &["-c", "curl -LsSf https://astral.sh/uv/install.sh | sh"]).await.0;
         if reinstalled {
@@ -1205,7 +1205,7 @@ async fn official_fallback(app: &tauri::AppHandle, tool: &str) -> bool {
     match tool {
         "uv" => {
             emit("[*] Installing uv via the official script…\n".into());
-            run_live(app, "powershell", vec!["-NoProfile".into(), "-Command".into(), "& { iwr -useb https://astral.sh/uv/install.ps1 | iex }".into()]).await
+            run_live(app, "powershell", vec!["-NoProfile".into(), "-ExecutionPolicy".into(), "Bypass".into(), "-Command".into(), "& { iwr -useb https://astral.sh/uv/install.ps1 | iex }".into()]).await
         }
         "git" => {
             // Live-resolve the newest release; pinned fallback keeps offline installs working.

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -478,6 +478,16 @@ pub async fn install(app: tauri::AppHandle, env_type: Option<String>) -> Result<
         mutating_done();
         return Err(format!("This folder is Pinokio-managed ({}). Installing here would corrupt Pinokio's Wan2GP. Pick an empty folder and reuse Pinokio's ckpts/loras/outputs as your model folders — no re-downloads, Pinokio keeps working.", where_.display()));
     }
+    // Fail fast on a full target drive: a complete install needs tens of GB
+    // (env alone is ~10 GB before models). Dying of ENOSPC 15 minutes into
+    // setup.py helps nobody — abort here with a copy-paste fix instead.
+    if let Some((free, _)) = crate::config::disk_for_path(&repo.to_string_lossy()) {
+        let free_gb = free as f64 / 1073741824.0;
+        if free_gb < 10.0 {
+            mutating_done();
+            return Err(format!("Only {free_gb:.1} GB free on the install drive ({}). A full install needs 50+ GB (env alone is ~10 GB before models). Free space or pick another folder, then retry — nothing was downloaded.", repo.display()));
+        }
+    }
     if repo.join("wgp.py").exists() {
         emit_phase("clone", "Clone Wan2GP repository", true);
     } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,7 +58,7 @@ pub fn run() {
             config::config_load, config::config_save, config::get_install_paths, config::get_disk_space, config::get_model_paths, config::detect_model_folders,
             config::install_plan, config::validate_install, config::uv_cache_info, config::uv_cache_size, config::manage_list,
             updates::get_desktop_version, updates::get_wangp_local_version, updates::get_desktop_git_info,
-            launch::launch, launch::stop_wangp, system::open_folder, system::select_folder, system::confirm_dialog, system::repair_settings,
+            launch::launch, launch::stop_wangp, system::open_folder, system::select_folder, system::confirm_dialog, system::repair_settings, system::reset_wgp_config,
             features::check_package, features::check_package_updates, features::deepy_status, features::memory_profile_read,
             features::auto_tune_detect, features::auto_tune_recommend,
             install::install, install::reinstall, install::uninstall, install::sync_kernels, install::update, install::dlss5_status, install::install_dlss5, install::classify_target, install::python_preflight, install::restore_backup, config::manage_set_active, config::uninstall_env,

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -174,8 +174,9 @@ fn scrub_config_lists(repo: &PathBuf, id: &str) -> Result<(), String> {
 // guard-free core: clone (+requirements) + record + enable. plugin_install wraps
 // it with the mutating guard; ensure_favorites calls it in a loop (best-effort).
 async fn install_plugin_inner(app: &tauri::AppHandle, url: &str) -> Result<String, String> {
-    use tauri_plugin_shell::ShellExt;
-    use tauri_plugin_shell::process::CommandEvent;
+    // Plaintext git clone is a MITM code-execution path (plugins load into
+    // Wan2GP). scp-style github.com: URLs ride over SSH and stay allowed.
+    if url.starts_with("http://") { return Err("refusing plaintext http:// plugin URL — use https://".into()); }
     let id = plugin_id_from_url(url);
     if id.is_empty() { return Err("Could not derive a plugin id from that URL".into()); }
     let repo = get_repo_dir();
@@ -184,14 +185,12 @@ async fn install_plugin_inner(app: &tauri::AppHandle, url: &str) -> Result<Strin
     if !target.exists() {
         log(&format!("[*] Cloning plugin {id}…\n"));
         std::fs::create_dir_all(repo.join("plugins")).map_err(|e| e.to_string())?;
-        let (mut rx, _) = app.shell().command("git").args(["clone", "--depth", "1", url, &target.to_string_lossy()]).spawn().map_err(|e| e.to_string())?;
-        while let Some(ev) = rx.recv().await {
-            match ev {
-                CommandEvent::Stdout(b) | CommandEvent::Stderr(b) => log(&String::from_utf8_lossy(&b)),
-                _ => {}
-            }
+        let target_s = target.to_string_lossy().to_string();
+        if !run_logged(app, "git", &["clone", "--depth", "1", url, target_s.as_str()], None, &log).await
+            || !target.exists()
+        {
+            return Err("git clone failed — check console output".into());
         }
-        if !target.exists() { return Err("git clone failed — check console output".into()); }
         install_requirements(app, &repo, &id, &target, &log).await;
     } else {
         log(&format!("[*] Plugin {id} already installed — enabling…\n"));
@@ -299,8 +298,6 @@ pub async fn plugin_check_updates(app: tauri::AppHandle) -> Result<serde_json::V
 
 #[tauri::command]
 pub async fn plugin_update(app: tauri::AppHandle, id: Option<String>) -> Result<serde_json::Value, String> {
-    use tauri_plugin_shell::ShellExt;
-    use tauri_plugin_shell::process::CommandEvent;
     let id = id.unwrap_or_default().trim().to_string();
     if !valid_plugin_id(&id) { return Err("Bad plugin id".into()); }
     let repo = get_repo_dir();
@@ -309,12 +306,10 @@ pub async fn plugin_update(app: tauri::AppHandle, id: Option<String>) -> Result<
     mutating_try("plugin-update")?;
     let log = |m: &str| { crate::base::push_log(m, "launch"); let _ = app.emit("launch-log", m.to_string()); };
     log(&format!("[*] Updating plugin {id}…\n"));
-    let (mut rx, _) = app.shell().command("git").args(["-C", &target.to_string_lossy(), "pull", "--ff-only"]).spawn().map_err(|e| { mutating_done(); e.to_string() })?;
-    while let Some(ev) = rx.recv().await {
-        match ev {
-            CommandEvent::Stdout(b) | CommandEvent::Stderr(b) => log(&String::from_utf8_lossy(&b)),
-            _ => {}
-        }
+    let target_s = target.to_string_lossy().to_string();
+    if !run_logged(&app, "git", &["-C", target_s.as_str(), "pull", "--ff-only"], None, &log).await {
+        mutating_done();
+        return Err(format!("Plugin {id} update failed (git pull) — see console output"));
     }
     install_requirements(&app, &repo, &id, &target, &log).await;
     mutating_done();
@@ -359,7 +354,8 @@ pub fn plugin_uninstall(id: Option<String>) -> Result<serde_json::Value, String>
 #[tauri::command]
 pub async fn plugin_install(app: tauri::AppHandle, url: Option<String>) -> Result<serde_json::Value, String> {
     let url = url.unwrap_or_default().trim().to_string();
-    if !(url.starts_with("https://") || url.starts_with("http://") || url.contains("github.com:")) {
+    // http:// is a MITM code-execution path (cloned code loads into Wan2GP).
+    if !(url.starts_with("https://") || url.contains("github.com:")) {
         return Err("Give a plugin git URL (https://github.com/…/…)".into());
     }
     if !get_repo_dir().join("wgp.py").exists() { return Err("Wan2GP not installed — run Install first".into()); }

--- a/src-tauri/src/status.rs
+++ b/src-tauri/src/status.rs
@@ -186,8 +186,9 @@ pub fn check_installed() -> serde_json::Value {
 
 #[tauri::command]
 pub fn check_command(cmd: String) -> serde_json::Value {
-    #[cfg(windows)] let probe = silent_command("where").arg(&cmd).output();
-    #[cfg(not(windows))] let probe = silent_command("which").arg(&cmd).output();
-    let found = probe.is_ok_and(|o| o.status.success());
+    // Windows: tool_usable filters the Store shim (a bare `where` hit is not
+    // proof of a runnable binary — see base::tool_usable).
+    #[cfg(windows)] let found = tool_usable(&cmd);
+    #[cfg(not(windows))] let found = silent_command("which").arg(&cmd).output().is_ok_and(|o| o.status.success());
     serde_json::json!({"cmd": cmd, "found": found})
 }

--- a/src-tauri/src/system.rs
+++ b/src-tauri/src/system.rs
@@ -204,7 +204,6 @@ pub fn repair_settings() -> serde_json::Value {
 /// Shared cross-device move used by move_folder and reinstall (model
 /// relocation before wipe). Emits migration-progress 0-100 on the slow path.
 pub(crate) async fn move_path_inner(app: &tauri::AppHandle, s: &Path, d: &Path) -> Result<serde_json::Value, String> {
-    use tauri::Emitter;
     if !s.exists() { return Err("Source folder not found".into()); }
     // Fast path: same-volume rename (instant, no progress needed).
     if std::fs::rename(s, d).is_ok() && !s.exists() {

--- a/src-tauri/src/system.rs
+++ b/src-tauri/src/system.rs
@@ -36,6 +36,22 @@ pub async fn confirm_dialog(app: tauri::AppHandle, opts: Option<serde_json::Valu
     let confirmed = app.dialog().message(&full).title(title).kind(MessageDialogKind::Info).blocking_show();
     serde_json::json!({"response": i32::from(!confirmed)})
 }
+/// Reset a broken/outdated wgp_config.json: back it up, delete the original
+/// so Wan2GP regenerates full defaults on next launch. Used when wgp.py dies
+/// with `KeyError: '<key>'` — the file exists but misses keys the installed
+/// wgp.py requires (partial write after a failed install, or an ancient
+/// config after an update). Never edits values, so no silent misconfiguration.
+#[tauri::command]
+pub fn reset_wgp_config() -> Result<serde_json::Value, String> {
+    let repo = get_repo_dir();
+    let cfg = repo.join("wgp_config.json");
+    if !cfg.exists() { return Err("wgp_config.json not found — nothing to reset".into()); }
+    let stamp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    let bak = repo.join(format!("wgp_config.bak-{stamp}.json"));
+    std::fs::copy(&cfg, &bak).map_err(|e| e.to_string())?;
+    std::fs::remove_file(&cfg).map_err(|e| e.to_string())?;
+    Ok(serde_json::json!({"ok": true, "success": true, "backup": bak.to_string_lossy().to_string()}))
+}
 // Settings repair — port of services/settings-repair.js (Electron).
 // Part 1: clamp dropdown values in models/_settings.json + every *_settings.json
 // (stale values make Gradio reject the whole form on save). Part 2: fix model

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
                                 }
                             ],
                 "security":  {
-                                 "csp":  null
+                                 "csp":  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; frame-src http://localhost:* http://127.0.0.1:*; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src 'none'; base-uri 'self'"
                              }
             },
     "bundle":  {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
                                 }
                             ],
                 "security":  {
-                                 "csp":  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; frame-src http://localhost:* http://127.0.0.1:*; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src 'none'; base-uri 'self'"
+                                 "csp":  "default-src \u0027self\u0027; script-src \u0027self\u0027; style-src \u0027self\u0027 \u0027unsafe-inline\u0027; img-src \u0027self\u0027 data: asset: http://asset.localhost; font-src \u0027self\u0027 data:; frame-src http://localhost:* http://127.0.0.1:*; connect-src \u0027self\u0027 http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; object-src \u0027none\u0027; base-uri \u0027self\u0027"
                              }
             },
     "bundle":  {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema":  "https://schema.tauri.app/config/2",
     "productName":  "Wan2GP Desktop Launcher Tauri",
-    "version":  "0.4.2",
+    "version":  "0.4.3",
     "identifier":  "com.wangp.desktop-tauri",
     "build":  {
                   "frontendDist":  "../src"

--- a/src/app.js
+++ b/src/app.js
@@ -3080,8 +3080,11 @@ $('taskMgrBtn').addEventListener('click',()=>{ window.w2gp.openTaskManager() })
 // Node-side mirror lives in services/normalize-pip-spec.js for unit tests.)
 function normalizePipSpec(raw) {
   let s = (raw || '').trim()
-  const m = s.match(/^(?:py(?:thon)?\s+-m\s+)?pip\s+install\s+/i)
+  const m = s.match(/^(?:py(?:thon)?\s+-m\s+)?pip3?\s+install\s+/i)
   if (m) s = s.slice(m[0].length).trim()
+  // Strip pip flags (`pip install foo --upgrade` → `foo`). UX only — the
+  // backend re-validates. Must match services/normalize-pip-spec.js.
+  s = s.split(/\s+/).filter((t) => !t.startsWith('-')).join(' ')
   return s
 }
 $('pipInstallBtn').addEventListener('click', async () => {
@@ -3109,12 +3112,14 @@ function updatePipCmdPreview() {
   if (!input || !preview || !text) return
   const spec = normalizePipSpec(input.value)
   if (!spec) { preview.style.display = 'none'; return }
-  // Reuse the same validation the launcher applies (kept in sync with main.js).
-  const name = spec.split(/[<>=!~]/)[0].replace(/\s/g, '')
-  const okName = /^[A-Za-z0-9._-]+$/.test(name) && /^[A-Za-z]/.test(name)
-  const hasInjection = /[;&|<>$`(){}'"]/.test(spec) || /\s-{1,2}[a-zA-Z]/.test(spec)
-  if (!okName) { preview.style.display = 'flex'; preview.classList.add('pip-cmd-bad'); text.textContent = '✗ Invalid package name' }
-  else if (hasInjection) { preview.style.display = 'flex'; preview.classList.add('pip-cmd-bad'); text.textContent = '✗ Flags/shell characters are blocked for safety' }
+  // Single source of truth: the same validator the backend enforces
+  // (services/pip-spec.js, exposed as window.PipSpec by the script tag in
+  // index.html). No inline copy — the old one wrongly blocked `<>` (valid
+  // PEP 440 operators), so `foo>=1.0` previewed as blocked but installed fine.
+  const check = window.PipSpec
+    ? window.PipSpec.assertSafePipSpec(spec)
+    : { ok: false, reason: 'validator missing' }
+  if (!check.ok) { preview.style.display = 'flex'; preview.classList.add('pip-cmd-bad'); text.textContent = '✗ Blocked: ' + (check.reason || 'invalid spec') }
   else { preview.style.display = 'flex'; preview.classList.remove('pip-cmd-bad'); text.textContent = 'pip install ' + spec + '   (runs in the active env)' }
 }
 $('pipInput').addEventListener('input', updatePipCmdPreview)

--- a/src/app.js
+++ b/src/app.js
@@ -3435,10 +3435,10 @@ async function refreshDlss5() {
 }
 $('dlss5InstallBtn')?.addEventListener('click', () => {
   $('dlss5AcceptInput').value = ''; $('dlss5ConfirmBtn').disabled = true
-  $('dlss5Modal').classList.add('open'); $('dlss5AcceptInput').focus()
+  $('dlss5Modal').classList.remove('hidden'); $('dlss5AcceptInput').focus()
 })
 $('dlss5AcceptInput')?.addEventListener('input', e => { $('dlss5ConfirmBtn').disabled = (e.target.value !== 'I ACCEPT') })
-$('dlss5CancelBtn')?.addEventListener('click', () => { $('dlss5Modal').classList.remove('open') })
+$('dlss5CancelBtn')?.addEventListener('click', () => { $('dlss5Modal').classList.add('hidden') })
 // ── DLSS5 file overview: one always-visible row per installed file (path +
 // version + expected SHA from the backend manifest) with installed /
 // not-installed state. Live install events only override the phase mid-install;
@@ -3525,7 +3525,7 @@ function dlss5OnEvent(d) {
 }
 $('dlss5ConfirmBtn')?.addEventListener('click', async () => {
   _dlss5LastPkg = null; _dlss5State = {}; _dlss5Done = false; renderDlss5Progress()
-  $('dlss5Modal').classList.remove('open')
+  $('dlss5Modal').classList.add('hidden')
   const force = !!$('dlss5ForceChk')?.checked
   const btn = $('dlss5InstallBtn'); btn.disabled = true
   const orig = btn.textContent; btn.textContent = 'Installing…'

--- a/src/app.js
+++ b/src/app.js
@@ -3435,10 +3435,10 @@ async function refreshDlss5() {
 }
 $('dlss5InstallBtn')?.addEventListener('click', () => {
   $('dlss5AcceptInput').value = ''; $('dlss5ConfirmBtn').disabled = true
-  $('dlss5Modal').style.display = 'flex'; $('dlss5AcceptInput').focus()
+  $('dlss5Modal').classList.add('open'); $('dlss5AcceptInput').focus()
 })
 $('dlss5AcceptInput')?.addEventListener('input', e => { $('dlss5ConfirmBtn').disabled = (e.target.value !== 'I ACCEPT') })
-$('dlss5CancelBtn')?.addEventListener('click', () => { $('dlss5Modal').style.display = 'none' })
+$('dlss5CancelBtn')?.addEventListener('click', () => { $('dlss5Modal').classList.remove('open') })
 // ── DLSS5 file overview: one always-visible row per installed file (path +
 // version + expected SHA from the backend manifest) with installed /
 // not-installed state. Live install events only override the phase mid-install;
@@ -3525,7 +3525,7 @@ function dlss5OnEvent(d) {
 }
 $('dlss5ConfirmBtn')?.addEventListener('click', async () => {
   _dlss5LastPkg = null; _dlss5State = {}; _dlss5Done = false; renderDlss5Progress()
-  $('dlss5Modal').style.display = 'none'
+  $('dlss5Modal').classList.remove('open')
   const force = !!$('dlss5ForceChk')?.checked
   const btn = $('dlss5InstallBtn'); btn.disabled = true
   const orig = btn.textContent; btn.textContent = 'Installing…'

--- a/src/app.js
+++ b/src/app.js
@@ -3434,10 +3434,10 @@ async function refreshDlss5() {
   renderDlss5Progress()
 }
 $('dlss5InstallBtn')?.addEventListener('click', () => {
-  $('dlss5AcceptInput').value = ''; $('dlss5ConfirmBtn').disabled = true
-  $('dlss5Modal').classList.remove('hidden'); $('dlss5AcceptInput').focus()
+  $('dlss5AcceptChk').checked = false; $('dlss5ConfirmBtn').disabled = true
+  $('dlss5Modal').classList.remove('hidden'); $('dlss5AcceptChk').focus()
 })
-$('dlss5AcceptInput')?.addEventListener('input', e => { $('dlss5ConfirmBtn').disabled = (e.target.value !== 'I ACCEPT') })
+$('dlss5AcceptChk')?.addEventListener('change', e => { $('dlss5ConfirmBtn').disabled = !e.target.checked })
 $('dlss5CancelBtn')?.addEventListener('click', () => { $('dlss5Modal').classList.add('hidden') })
 // ── DLSS5 file overview: one always-visible row per installed file (path +
 // version + expected SHA from the backend manifest) with installed /

--- a/src/app.js
+++ b/src/app.js
@@ -2939,6 +2939,7 @@ window.w2gp.onWangpExit(c => {
   // (Was interpolating the whole object → "exited (code [object Object])".)
   const code = (c && typeof c === 'object') ? (c.code ?? (c.stopped ? 0 : '?')) : c
   appendLog(`${code === 0 ? '[*]' : '[!]'} Wan2GP process exited (code ${code})`)
+  const exitMode = serverMode // capture before teardown below nulls it
   _pendingOpen = null   // boot failed/went away — don't open anything later
   // Server is really gone: drop the (now stale) embed entirely so the next
   // open rebuilds it instead of showing a dead page.
@@ -2954,7 +2955,46 @@ window.w2gp.onWangpExit(c => {
   $('stopWangpBtn').style.display = 'none'
   updateLed('stopped')
   updateFtStatus('stopped')
+  // Config-skew recovery: wgp.py died with KeyError on a settings key —
+  // wgp_config.json exists but misses keys the installed wgp.py requires
+  // (partial write after a failed install, or an ancient config after an
+  // update). Offer backup + reset + relaunch instead of a dead dashboard.
+  if (code !== 0 && code !== '?' && !window._configCrashOffered) {
+    try {
+      const tail = (typeof window._getLogTail === 'function') ? window._getLogTail() : ''
+      const m = tail.match(/KeyError:\s*'([^']+)'/)
+      if (m && /wgp\.py/.test(tail)) {
+        window._configCrashOffered = true
+        offerConfigReset(m[1], exitMode)
+      }
+    } catch {}
+  }
 })
+
+async function offerConfigReset(missingKey, mode) {
+  appendLog(`[!] Wan2GP crashed: settings file is missing '${missingKey}' (outdated or partial wgp_config.json).`)
+  showToast(`✗ Settings missing '${missingKey}' — reset offered`)
+  const choice = await window.w2gp.confirmDialog({
+    title: 'Settings file outdated?',
+    message: `Wan2GP crashed because wgp_config.json is missing '${missingKey}'.`,
+    detail: 'Back it up and reset to defaults? Wan2GP regenerates the full file on next launch (models stay where they are).'
+  })
+  window._configCrashOffered = false
+  if (choice !== 'ok') return
+  try {
+    const r = await window.w2gp.resetWgpConfig()
+    if (r && (r.success || r.ok)) {
+      appendLog('[*] Settings backed up to ' + (r.backup || 'wgp_config.bak-*.json') + ' — relaunching with fresh defaults…')
+      showToast('✓ Settings reset — relaunching')
+      setTimeout(function() {
+        // Reuse the dashboard buttons' full logic (validation, boot flow).
+        const b = (mode === 'browser') ? $('browserBtn') : $('appBtn')
+        if (b && !b.disabled) b.click()
+        else showToast('Press Launch to start Wan2GP with fresh settings')
+      }, 800)
+    } else showToast('✗ Reset failed: ' + ((r && r.error) || 'unknown'))
+  } catch (e) { showToast('✗ ' + errText(e)) }
+}
 
 // ── Floating Terminal (Desktop/webview mode only) ──
 function updateFtStatus(state) {

--- a/src/index.html
+++ b/src/index.html
@@ -1123,6 +1123,7 @@
   <!-- Tauri shim: provides window.w2gp via invoke() — ponytail: one file replaces 9600L preload.js -->
   <script src="w2gp.js" defer></script>
   <script src="services/escape.js" defer></script>
+  <script src="services/pip-spec.js" defer></script>
   <script src="app.js" defer></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -679,9 +679,8 @@
         <div id="dlss5Modal" class="modal-overlay hidden">
           <div class="modal-box">
             <h3 style="margin:0 0 8px">Install DLSS 5 runtime?</h3>
-            <p class="path-hint">This downloads native third-party binaries (NVIDIA DLSS, ReShade, RenoDX, DLSSNR 310.8.SF-v2 — community-hosted, unsigned, proprietary) with GPU and filesystem access. Wan2GP does not grant redistribution rights or guarantee these files. Continue only if you accept the copyright, licensing, and security risks. Details: <a id="dlss5DocsLink2" href="#" style="color:var(--accent)">docs/DLSS5.md</a></p>
-            <p class="path-hint">Type <code>I ACCEPT</code> to continue:</p>
-            <input type="text" id="dlss5AcceptInput" class="input" placeholder="I ACCEPT" style="width:100%;margin-bottom:10px" autocomplete="off">
+            <p class="path-hint">This downloads and runs native third-party binaries — NVIDIA DLSS, ReShade, RenoDX and DLSSNR 310.8.SF-v2. They are community-hosted, unsigned and proprietary, with GPU and filesystem access. Wan2GP grants no redistribution rights and guarantees nothing about these files. Details: <a id="dlss5DocsLink2" href="#" style="color:var(--accent)">docs/DLSS5.md</a></p>
+            <label class="path-hint" style="display:flex;gap:8px;align-items:flex-start;margin:10px 0 12px;cursor:pointer"><input type="checkbox" id="dlss5AcceptChk" style="margin-top:2px"> <span>I accept the copyright, licensing, and security risks above.</span></label>
             <div style="display:flex;gap:8px;justify-content:flex-end">
               <button class="btn btn-ghost" id="dlss5CancelBtn">Cancel</button>
               <button class="btn btn-primary" id="dlss5ConfirmBtn" disabled>Install</button>

--- a/src/index.html
+++ b/src/index.html
@@ -673,9 +673,12 @@
           <p class="path-hint" style="margin-top:4px"><em>Stop Wan2GP first — files under <code>dlss5/</code> can't be replaced while in use.</em></p>
         </div>
 
-        <!-- Strict-consent modal: type I ACCEPT to run the third-party installer. -->
-        <div id="dlss5Modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:99;align-items:center;justify-content:center">
-          <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:18px;max-width:520px;margin:10vh auto">
+        <!-- Strict-consent modal: type I ACCEPT to run the third-party installer.
+             Class-based overlay (see .modal-overlay in style.css) — never inline
+             display/position styles, so a dropped style="" can't silently turn
+             the popup into an in-flow block. -->
+        <div id="dlss5Modal" class="modal-overlay">
+          <div class="modal-box">
             <h3 style="margin:0 0 8px">Install DLSS 5 runtime?</h3>
             <p class="path-hint">This downloads native third-party binaries (NVIDIA DLSS, ReShade, RenoDX, DLSSNR 310.8.SF-v2 — community-hosted, unsigned, proprietary) with GPU and filesystem access. Wan2GP does not grant redistribution rights or guarantee these files. Continue only if you accept the copyright, licensing, and security risks. Details: <a id="dlss5DocsLink2" href="#" style="color:var(--accent)">docs/DLSS5.md</a></p>
             <p class="path-hint">Type <code>I ACCEPT</code> to continue:</p>

--- a/src/index.html
+++ b/src/index.html
@@ -674,10 +674,9 @@
         </div>
 
         <!-- Strict-consent modal: type I ACCEPT to run the third-party installer.
-             Class-based overlay (see .modal-overlay in style.css) — never inline
-             display/position styles, so a dropped style="" can't silently turn
-             the popup into an in-flow block. -->
-        <div id="dlss5Modal" class="modal-overlay">
+             Same convention as migrationModal/backupModal below: hidden via the
+             `hidden` class, shown by removing it. -->
+        <div id="dlss5Modal" class="modal-overlay hidden">
           <div class="modal-box">
             <h3 style="margin:0 0 8px">Install DLSS 5 runtime?</h3>
             <p class="path-hint">This downloads native third-party binaries (NVIDIA DLSS, ReShade, RenoDX, DLSSNR 310.8.SF-v2 — community-hosted, unsigned, proprietary) with GPU and filesystem access. Wan2GP does not grant redistribution rights or guarantee these files. Continue only if you accept the copyright, licensing, and security risks. Details: <a id="dlss5DocsLink2" href="#" style="color:var(--accent)">docs/DLSS5.md</a></p>

--- a/src/services/install-plan.js
+++ b/src/services/install-plan.js
@@ -74,10 +74,10 @@ function buildPlan(hw = {}) {
       }
       notes.push('RTX 20/30/40/50 → CUDA 13 stack (needs R580+ driver).')
     }
-    // Attention kernels Wan2GP installs for NVIDIA
+    // Attention kernels Wan2GP installs for NVIDIA (Sparge needs SM ≥ 7.0 —
+    // true for every card reaching this branch, so it stays in the base list).
     attention = ['SageAttention', 'FlashAttention', 'SpargeAttention']
     if (cap >= 9.0) attention.push('Nunchaku + GGUF', 'LightX2V')
-    if (cap >= 7.0) attention.push('SpargeAttention')
   } else if (vendor === 'AMD') {
     cuda = 'ROCm (TheRock)'
     torch = 'PyTorch 2.7.0'

--- a/src/services/kernel-resolver.js
+++ b/src/services/kernel-resolver.js
@@ -13,7 +13,10 @@
 /**
  * Map a detected GPU to Wan2GP's setup_config.json GPU-profile key.
  * Mirrors the upstream setup.py profile names (RTX_50, RTX_40, RTX_30, RTX_20,
- * GTX_10, AMD_GFX110X, AMD_GFX1151, AMD_GFX1201, MPS) plus the Intel default.
+ * GTX_10, AMD_GFX110X, AMD_GFX1151, AMD_GFX1201, MPS) plus INTEL_XPU for Intel
+ * (XPU backend — see install-plan.js) and CPU for unknown vendors. Unknown
+ * hardware must NEVER alias an NVIDIA profile: the overview would promise
+ * CUDA wheels the installer never installs.
  *
  * @param {{name?:string, vendor?:string}} gpu
  * @returns {string} profile key
@@ -39,7 +42,8 @@ function kernelProfileKey(gpu) {
     if (/9000|9060|9070|8000|1201/.test(g)) return 'AMD_GFX1201'
     return 'AMD_GFX110X'
   }
-  return 'RTX_40' // setup.py default fallback for unknown/Intel
+  if (vendor === 'INTEL') return 'INTEL_XPU' // Arc/iGPU → XPU backend, no CUDA wheels
+  return 'CPU' // unknown vendor — claim nothing rather than NVIDIA wheels
 }
 
 /**

--- a/src/services/normalize-pip-spec.js
+++ b/src/services/normalize-pip-spec.js
@@ -1,14 +1,19 @@
 /**
  * normalize-pip-spec.js — accept either a bare pip spec
  * (claude-agent-sdk==0.1.40) or a full command pasted by a user
- * (pip install claude-agent-sdk==0.1.40 / python -m pip install ...) and strip
- * the leading pip invocation so the preview and the real install handler see the
- * same spec. Pure + offline-testable.
+ * (pip install claude-agent-sdk==0.1.40 / pip3 install foo /
+ * python -m pip install ...) and strip the leading pip invocation plus any
+ * pip flags so the preview and the real install handler see the same spec.
+ * Pure + offline-testable. UX normalization only — the backend re-validates
+ * the result (services/pip-spec.js + Rust port), so nothing here is a
+ * security boundary.
  */
 function normalizePipSpec(raw) {
   let s = (raw || '').trim()
-  const m = s.match(/^(?:py(?:thon)?\s+-m\s+)?pip\s+install\s+/i)
+  const m = s.match(/^(?:py(?:thon)?\s+-m\s+)?pip3?\s+install\s+/i)
   if (m) s = s.slice(m[0].length).trim()
+  // Strip pip flags (`pip install foo --upgrade` → `foo`).
+  s = s.split(/\s+/).filter((t) => !t.startsWith('-')).join(' ')
   return s
 }
 

--- a/src/services/pip-spec.js
+++ b/src/services/pip-spec.js
@@ -70,4 +70,7 @@ function assertSafePipSpec(spec) {
   return { ok: true, name }
 }
 
-module.exports = { assertSafePipSpec, NAME_RE, URL_RE }
+// Dual-target: node --test suite via require(), renderer via a plain <script>
+// tag (see index.html — same pattern as services/escape.js).
+if (typeof module === 'object' && module.exports) module.exports = { assertSafePipSpec, NAME_RE, URL_RE }
+if (typeof window !== 'undefined') window.PipSpec = { assertSafePipSpec, NAME_RE, URL_RE }

--- a/src/services/spawn-cmd.js
+++ b/src/services/spawn-cmd.js
@@ -17,8 +17,9 @@
  *     shell to misinterpret metacharacters.
  *
  * Args are assumed to be static/safe (validated callers: npm package name regex,
- * fixed serve flags). They are joined for the shell case; if you ever pass
- * user-derived args, escape them before calling this.
+ * fixed serve flags). They are joined for the shell case; user-derived args
+ * are escaped (cmd.exe double-quote rules) with a loud warning so a future
+ * caller can't silently introduce injection.
  *
  * @param {string} bin   resolved executable (from resolveCmd, may contain spaces)
  * @param {string[]} args argv (excluding argv[0])
@@ -29,14 +30,38 @@ function isBatchFile(bin) {
   return /\.(cmd|bat)$/i.test(bin)
 }
 
+// Single safe token: word chars plus the punctuation fixed flags/paths need.
+// NOTE: this class also matches leading dashes, so option-like tokens get a
+// dedicated check below — quoting neutralizes shell metacharacters but can
+// never neutralize a flag (`"--flag"` is still a flag to the callee).
+const SAFE_ARG_RE = /^[\w.:/-]+$/
+
+// cmd.exe quoting: wrap in double quotes, double any embedded quotes.
+function escapeArg(a) {
+  return `"${String(a).replace(/"/g, '""')}"`
+}
+
+// Classify one arg: null = static-safe, 'chars' = shell-risky (escaped),
+// 'flag' = option-like (warned; must be a conscious caller choice).
+function argRisk(a) {
+  const s = String(a)
+  if (!SAFE_ARG_RE.test(s)) return 'chars'
+  if (s.startsWith('-')) return 'flag'
+  return null
+}
+
 function spawnCmd(bin, args = [], opts = {}) {
   const { spawn } = require('child_process')
+  const risky = args.map((a) => ({ arg: a, risk: argRisk(a) })).filter((r) => r.risk)
+  if (risky.length) console.warn('[spawn-cmd] non-static args:', risky)
   if (isBatchFile(bin)) {
     // Quote the bin so "C:\Program Files\..." is one token; /s makes cmd honor it.
-    const command = `"${bin}" ${args.join(' ')}`
+    // Safe args join verbatim; shell-risky args are cmd.exe-quoted (fail-closed).
+    const joined = args.map((a) => (argRisk(a) === 'chars' ? escapeArg(a) : a)).join(' ')
+    const command = `"${bin}" ${joined}`
     return spawn(command, [], { ...opts, shell: true })
   }
   return spawn(bin, args, { ...opts, shell: false })
 }
 
-module.exports = { spawnCmd, isBatchFile }
+module.exports = { spawnCmd, isBatchFile, escapeArg, SAFE_ARG_RE, argRisk }

--- a/src/style.css
+++ b/src/style.css
@@ -492,6 +492,13 @@ body {
 .deepy-enhancer-note { font-size: 0.5rem; color: var(--text-tertiary); font-style: italic; }
 .deepy-enhancer-label { font-weight: 600; color: var(--text-primary); }
 .deepy-actions { display: flex; gap: 8px; margin-top: 10px; }
+
+/* ── Modal overlay (class-based, never inline styles: the overlay MUST survive
+   any environment that drops style="" attributes — an in-flow consent block
+   looks identical to a working modal's content but blocks nothing). ── */
+.modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.65); z-index: 99; align-items: center; justify-content: center; }
+.modal-overlay.open { display: flex; }
+.modal-box { background: var(--surface); border: 1px solid var(--border-hover); border-radius: 10px; padding: 18px; max-width: 520px; width: calc(100% - 40px); margin: 10vh auto; box-shadow: 0 18px 60px rgba(0,0,0,.55); }
 .dot-ok { color: #4ADE80; }
 .dot-bad { color: #F87171; }
 

--- a/src/style.css
+++ b/src/style.css
@@ -493,11 +493,8 @@ body {
 .deepy-enhancer-label { font-weight: 600; color: var(--text-primary); }
 .deepy-actions { display: flex; gap: 8px; margin-top: 10px; }
 
-/* ── Modal overlay (class-based, never inline styles: the overlay MUST survive
-   any environment that drops style="" attributes — an in-flow consent block
-   looks identical to a working modal's content but blocks nothing). ── */
-.modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.65); z-index: 99; align-items: center; justify-content: center; }
-.modal-overlay.open { display: flex; }
+/* ── DLSS consent box (outer overlay comes from the shared .modal-overlay
+   system below — hidden via the `hidden` class like migrationModal). ── */
 .modal-box { background: var(--surface); border: 1px solid var(--border-hover); border-radius: 10px; padding: 18px; max-width: 520px; width: calc(100% - 40px); margin: 10vh auto; box-shadow: 0 18px 60px rgba(0,0,0,.55); }
 .dot-ok { color: #4ADE80; }
 .dot-bad { color: #F87171; }

--- a/src/w2gp.js
+++ b/src/w2gp.js
@@ -28,6 +28,7 @@
     folderSize: (path) => call('folder_size', { path }),
     isDataDirRoaming: () => call('is_data_dir_roaming'),
     writeWgpConfig: (cfg) => call('write_wgp_config', { cfg }), selectFolder: () => call('select_folder'),
+    resetWgpConfig: () => call('reset_wgp_config'),
     confirmDialog: async (opts) => {
         try { const r = await call('confirm_dialog', { opts }); if (typeof r==='string') return r; if (r && typeof r.choice==='string') return r.choice; if (r && typeof r.response==='number') return r.response===0 ? 'ok' : 'cancel'; if (r && r.ok) return 'ok'; return r; } catch { return 'cancel'; }
     }, detectModelFolders: () => call('detect_model_folders'),


### PR DESCRIPTION
What your test runs already proved on the clean PC, now for review.

**Security**
- Backend pip spec guard (Rust port of pip-spec.js + tests): blocks --flags/-r/-e/http tarballs
- https-only plugin installs (MITM code-exec path closed, incl. favoritePlugins)
- Capability trim (unused shell/fs/dialog JS APIs removed) + baseline CSP
- spawn-cmd.js: arg assert + cmd.exe escaping, option-like tokens flagged

**Correctness (no more false success)**
- Exit-code propagation: pip cmds, requirements restore, git pull update, per-kernel sync (names the failed wheel), plugin clone/pull
- Winget Python exact-pin check with pinned fallback; Store-shim filter in both probes
- Intel XPU / CPU profile fallback (both JS + Rust) — no more NVIDIA wheels on Arc

**Installer that finishes**
- Git live-resolve + SHA-pinned installers; Python fallback 3.11.9 (3.11.14 ships no binary); uv fallback Bypass fix
- Fail fast on <10 GB install drive (mirrors model-drive gate)
- KeyError crash recovery (backup + reset + relaunch); DLSS consent checkbox popup (shared modal convention)

**Verified:** cargo test 5/5, zero warnings, clean-PC install log, DLSS popup eyeballed, v0.4.3 release already public from this branch.